### PR TITLE
Change configfs folder from c.2 to c.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ KERNEL_DIR	?= /usr/src/linux
 
 CC		:= $(CROSS_COMPILE)gcc
 KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
+
 # For 720p
-#CFLAGS			:= -W -Wall -g $(KERNEL_INCLUDE)
-#LDFLAGS		:= -g
+CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE)
+LDFLAGS		:= -g
 
 # For 1080p
-CFLAGS          := -W -Wall -O3 $(KERNEL_INCLUDE)
-LDFLAGS         := -O3g
+#CFLAGS    := -W -Wall -O3 $(KERNEL_INCLUDE)
+#LDFLAGS   := -O3g
 
 all: uvc-gadget
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ KERNEL_DIR	?= /usr/src/linux
 
 CC		:= $(CROSS_COMPILE)gcc
 KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
+# For 720p
+#CFLAGS			:= -W -Wall -g $(KERNEL_INCLUDE)
+#LDFLAGS		:= -g
+
+# For 1080p
 CFLAGS          := -W -Wall -O3 $(KERNEL_INCLUDE)
-LDFLAGS         := -O3
+LDFLAGS         := -O3g
 
 all: uvc-gadget
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,8 @@ KERNEL_DIR	?= /usr/src/linux
 
 CC		:= $(CROSS_COMPILE)gcc
 KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
-
-# For 720p
-CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE)
-LDFLAGS		:= -g
-
-# For 1080p
-#CFLAGS    := -W -Wall -O3 $(KERNEL_INCLUDE)
-#LDFLAGS   := -O3g
+CFLAGS    := -W -Wall -O3 $(KERNEL_INCLUDE)
+LDFLAGS   := -O3g
 
 all: uvc-gadget
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ KERNEL_DIR	?= /usr/src/linux
 
 CC		:= $(CROSS_COMPILE)gcc
 KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
-CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE)
-LDFLAGS		:= -g
+CFLAGS          := -W -Wall -O3 $(KERNEL_INCLUDE)
+LDFLAGS         := -O3
 
 all: uvc-gadget
 

--- a/README-old
+++ b/README-old
@@ -1,4 +1,4 @@
-UVC gadget test application Readme
+## UVC Gadget Application for Pi Webcam
 
 Copyright (C) 2010 Ideas on board SPRL
 Copyright (C) 2013 ST Microelectronics Ltd.
@@ -9,6 +9,10 @@ Bhupesh Sharma <bhupesh.sharma@st.com>
 
 Introduction
 ============
+
+> **TODO**: This README needs to be subsumed into the main README at some point.
+>
+> – geerlingguy
 
 This README file documents the UVC gadget test application available
 here git://git.ideasonboard.org/uvc-gadget.git, which can be used to

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,8 @@
 >
 > Anyways, check out https://github.com/geerlingguy/pi-webcam for the downstream and user-friendly usage of this project.
 >
+> The main thing is you can choose once (for now) between 720p or 1080p when you set this up—the project currently defaults to 720p, but if you want to switch to 1080p, then BEFORE you run this stuff, find the code with 'For 720p' and comment those parts out, and find the code with 'For 1080p' and uncomment those parts. I hope to make this all so much simpler in the future, allowing easier selection.
+>
 > – geerlingguy
 
 **Upstream project [uvc-gadget](http://git.ideasonboard.org/uvc-gadget.git) has been updated and continuous maintenance**

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,13 @@
 ## uvc-gadget
 
+> **NOTE**: This repository was originally forked from https://github.com/climberhunt/uvc-gadget, which itself was forked from https://github.com/wlhe/uvc-gadget, which is a fork from the original project... so it's a little bit of a mess here. Anyways, this little aside at the top of the README is the only bit that I have updated in the README so far.
+>
+> To be perfectly honest, I am still trying to learn the ins-and-outs of uvc-gadget and OTG usage before I feel confident enough to make the README actually comprehensible to humans who are not neck-deep in this stuff. I love good documentation, but I hate misleading or hard-to-read documentation.
+>
+> Anyways, check out https://github.com/geerlingguy/pi-webcam for the downstream and user-friendly usage of this project.
+>
+> – geerlingguy
+
 **Upstream project [uvc-gadget](http://git.ideasonboard.org/uvc-gadget.git) has been updated and continuous maintenance**
 
 **Please refer to http://git.ideasonboard.org/uvc-gadget.git**

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# TODO: Document this file. There's... a lot going on in here.
 mkdir /sys/kernel/config/usb_gadget/pi4
 
 echo 0x1d6b > /sys/kernel/config/usb_gadget/pi4/idVendor
@@ -13,7 +14,7 @@ echo 0x01 > /sys/kernel/config/usb_gadget/pi4/bDeviceProtocol
 mkdir /sys/kernel/config/usb_gadget/pi4/strings/0x409
 echo 100000000d2386db > /sys/kernel/config/usb_gadget/pi4/strings/0x409/serialnumber
 echo "Samsung" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/manufacturer
-echo "PI4 USB Device" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/product
+echo "Pi Webcam" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/product
 mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2
 mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2/strings/0x409
 echo 500 > /sys/kernel/config/usb_gadget/pi4/configs/c.2/MaxPower
@@ -24,6 +25,28 @@ mkdir /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0
 mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h
 ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/class/fs
 
+# For 720p:
+mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
+5000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
+1280
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wHeight
+720
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMinBitRate
+10000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxBitRate
+100000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxVideoFrameBufferSize
+7372800
+EOF
+
+# For 1080p:
 mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
 cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
 5000000
@@ -44,7 +67,6 @@ cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg
 7372800
 EOF
 
-
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
 cd /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
 ln -s ../../mjpeg/m
@@ -58,4 +80,3 @@ ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0 /sys/kernel/config/us
 ln -s /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.2/acm.usb0
 udevadm settle -t 5 || :
 ls /sys/class/udc > /sys/kernel/config/usb_gadget/pi4/UDC
-

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -47,25 +47,25 @@ cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg
 EOF
 
 # For 1080p:
-mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
-5000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
-1920
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
-1080
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
-10000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
-100000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
-7372800
-EOF
+# mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+# 5000000
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
+# 1920
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
+# 1080
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+# 10000000
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+# 100000000
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+# 7372800
+# EOF
 
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
 cd /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -26,46 +26,46 @@ mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h
 ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/class/fs
 
 # For 720p:
-mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
-5000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
-1280
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wHeight
-720
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMinBitRate
-10000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxBitRate
-100000000
-EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxVideoFrameBufferSize
-7372800
-EOF
-
-# For 1080p:
-# mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+# mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
 # 5000000
 # EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
-# 1920
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
+# 1280
 # EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
-# 1080
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wHeight
+# 720
 # EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMinBitRate
 # 10000000
 # EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxBitRate
 # 100000000
 # EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxVideoFrameBufferSize
 # 7372800
 # EOF
+
+# For 1080p:
+mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+5000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
+1920
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
+1080
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+10000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+100000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+7372800
+EOF
 
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
 cd /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -15,10 +15,10 @@ mkdir /sys/kernel/config/usb_gadget/pi4/strings/0x409
 echo 100000000d2386db > /sys/kernel/config/usb_gadget/pi4/strings/0x409/serialnumber
 echo "Samsung" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/manufacturer
 echo "Pi Webcam" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/product
-mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2
-mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2/strings/0x409
-echo 500 > /sys/kernel/config/usb_gadget/pi4/configs/c.2/MaxPower
-echo "UVC" > /sys/kernel/config/usb_gadget/pi4/configs/c.2/strings/0x409/configuration
+mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.1
+mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.1/strings/0x409
+echo 500 > /sys/kernel/config/usb_gadget/pi4/configs/c.1/MaxPower
+echo "UVC" > /sys/kernel/config/usb_gadget/pi4/configs/c.1/strings/0x409/configuration
 
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -28,7 +28,7 @@ ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys
 # For 720p:
 # mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
 # cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
-# 5000000
+# 333333
 # EOF
 # cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
 # 1280
@@ -49,7 +49,7 @@ ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys
 # For 1080p:
 mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
 cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
-5000000
+333333
 EOF
 cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
 1920

--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -26,46 +26,46 @@ mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h
 ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/class/fs
 
 # For 720p:
-# mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
-# 333333
-# EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
-# 1280
-# EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wHeight
-# 720
-# EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMinBitRate
-# 10000000
-# EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxBitRate
-# 100000000
-# EOF
-# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxVideoFrameBufferSize
-# 7372800
-# EOF
-
-# For 1080p:
-mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwFrameInterval
 333333
 EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
-1920
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wWidth
+1280
 EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
-1080
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/wHeight
+720
 EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMinBitRate
 10000000
 EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxBitRate
 100000000
 EOF
-cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/720p/dwMaxVideoFrameBufferSize
 7372800
 EOF
+
+# For 1080p:
+# mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+# 333333
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
+# 1920
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
+# 1080
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+# 10000000
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+# 100000000
+# EOF
+# cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+# 7372800
+# EOF
 
 mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
 cd /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h

--- a/piwebcam
+++ b/piwebcam
@@ -9,5 +9,7 @@ sudo /home/pi/uvc-gadget/multi-gadget.sh
 /usr/bin/v4l2-ctl -c contrast=20
 /usr/bin/v4l2-ctl -c video_bitrate=25000000
 
-# Configure the stream with uvc-gadget.
+# For 720p:
 sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0
+# For 1080p:
+# sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r1 -u /dev/video1 -v /dev/video0

--- a/piwebcam
+++ b/piwebcam
@@ -1,9 +1,7 @@
 #!/bin/bash
-#
 sudo /home/pi/uvc-gadget/multi-gadget.sh
 /usr/bin/v4l2-ctl -c auto_exposure=0
 /usr/bin/v4l2-ctl -c auto_exposure_bias=8
 /usr/bin/v4l2-ctl -c contrast=20
 /usr/bin/v4l2-ctl -c video_bitrate=25000000
 sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s2 -r1  -u /dev/video1 -v /dev/video0
-

--- a/piwebcam
+++ b/piwebcam
@@ -1,7 +1,13 @@
 #!/bin/bash
+
+# Run multi-gadget setup script.
 sudo /home/pi/uvc-gadget/multi-gadget.sh
+
+# Set some camera control options.
 /usr/bin/v4l2-ctl -c auto_exposure=0
 /usr/bin/v4l2-ctl -c auto_exposure_bias=8
 /usr/bin/v4l2-ctl -c contrast=20
 /usr/bin/v4l2-ctl -c video_bitrate=25000000
-sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s2 -r1  -u /dev/video1 -v /dev/video0
+
+# Configure the stream with uvc-gadget.
+sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0

--- a/piwebcam
+++ b/piwebcam
@@ -10,6 +10,6 @@ sudo /home/pi/uvc-gadget/multi-gadget.sh
 /usr/bin/v4l2-ctl -c video_bitrate=25000000
 
 # For 720p:
-sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0
+# sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0
 # For 1080p:
-# sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r1 -u /dev/video1 -v /dev/video0
+sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r1 -u /dev/video1 -v /dev/video0

--- a/piwebcam
+++ b/piwebcam
@@ -10,6 +10,6 @@ sudo /home/pi/uvc-gadget/multi-gadget.sh
 /usr/bin/v4l2-ctl -c video_bitrate=25000000
 
 # For 720p:
-# sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0
+sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r0 -u /dev/video1 -v /dev/video0
 # For 1080p:
-sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r1 -u /dev/video1 -v /dev/video0
+#sudo /home/pi/uvc-gadget/uvc-gadget -f1 -s1 -r1 -u /dev/video1 -v /dev/video0

--- a/piwebcam.service
+++ b/piwebcam.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Stars pi webcam service
+Description=Pi webcam
 
 [Service]
 ExecStart=/home/pi/uvc-gadget/piwebcam

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -39,8 +39,8 @@
 #include "uvc.h"
 
 
-#define WIDTH1  640
-#define HEIGHT1 360
+#define WIDTH1  1280
+#define HEIGHT1 720
 
 #define WIDTH2	1920
 #define HEIGHT2 1080
@@ -2043,8 +2043,8 @@ static void usage(const char *argv0)
             "1 = USER_PTR\n");
     fprintf(stderr,
             " -r <resolution> Select frame resolution:\n\t"
-            "0 = HEIGHT1p, VGA (WIDTH1xHEIGHT1)\n\t"
-            "1 = 720p, (WIDTH2xHEIGHT2)\n");
+            "0 = HEIGHT1p, (WIDTH1xHEIGHT1)\n\t"
+            "1 = HEIGHT2p, (WIDTH2xHEIGHT2)\n");
     fprintf(stderr,
             " -s <speed>	Select USB bus speed (b/w 0 and 2)\n\t"
             "0 = Full Speed (FS)\n\t"

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -2043,8 +2043,9 @@ static void usage(const char *argv0)
             "1 = USER_PTR\n");
     fprintf(stderr,
             " -r <resolution> Select frame resolution:\n\t"
-            "0 = HEIGHT1p, (WIDTH1xHEIGHT1)\n\t"
-            "1 = HEIGHT2p, (WIDTH2xHEIGHT2)\n");
+            "0 = %sp, (%sx%s)\n\t"
+            "1 = %sp, (%sx%s)\n", HEIGHT1, WIDTH1, HEIGHT1,
+            HEIGHT2, WIDTH2, HEIGHT2);
     fprintf(stderr,
             " -s <speed>	Select USB bus speed (b/w 0 and 2)\n\t"
             "0 = Full Speed (FS)\n\t"
@@ -2071,7 +2072,7 @@ int main(int argc, char *argv[])
     int dummy_data_gen_mode = 0;
     /* Frame format/resolution related params. */
     int default_format = 0;     /* V4L2_PIX_FMT_YUYV */
-    int default_resolution = 0; /* VGA HEIGHT1p */
+    int default_resolution = 0; /* 720p */
     int nbufs = 2;              /* Ping-Pong buffers */
     /* USB speed related params */
     int mult = 0;

--- a/uvc-gadget.c
+++ b/uvc-gadget.c
@@ -2043,8 +2043,8 @@ static void usage(const char *argv0)
             "1 = USER_PTR\n");
     fprintf(stderr,
             " -r <resolution> Select frame resolution:\n\t"
-            "0 = %sp, (%sx%s)\n\t"
-            "1 = %sp, (%sx%s)\n", HEIGHT1, WIDTH1, HEIGHT1,
+            "0 = %dp, (%dx%d)\n\t"
+            "1 = %dp, (%dx%d)\n", HEIGHT1, WIDTH1, HEIGHT1,
             HEIGHT2, WIDTH2, HEIGHT2);
     fprintf(stderr,
             " -s <speed>	Select USB bus speed (b/w 0 and 2)\n\t"


### PR DESCRIPTION
This change should fix the issue of the camera not being detected on Mac OS 12.0.1 Monterey